### PR TITLE
Reduce build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,5 +9,5 @@ lib:
 	mkdir -p lib
 
 clean:
-	rm -fr include/ lib/
+	rm -fr include/ lib/ openss-1.0.1m/
 


### PR DESCRIPTION
- Instead of committing pre-build binary, we try to reduce the build time.
- Do not build armv7s arch. (We only need armv7 + arm64.)
- Only do make install once. (Only need one copy of headers)
- Enable parallel make for compilation.
- The total build time (on my Macbook pro 13") is cut in half; from 6m10s to 2m54s.
